### PR TITLE
Fix Voltek Rel Database local path in main project file. 

### DIFF
--- a/Creation Kit Platform Extended.sln
+++ b/Creation Kit Platform Extended.sln
@@ -33,7 +33,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UnicodeConverter", "Depende
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VoltekLib", "VoltekLib", "{E3CCD384-8F82-4300-9B4A-DCAE5BA8DB89}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RelocationDatabase", "..\VoltekLib\Relocation Database\RelocationDatabase.vcxproj", "{2E2B6346-5155-45BC-AF2D-CFB47BE95CAB}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RelocationDatabase", "Dependencies\Voltek\Relocation Database\RelocationDatabase.vcxproj", "{2E2B6346-5155-45BC-AF2D-CFB47BE95CAB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This corrects the pathing for the sub-dependency in the main project file to prevent an error on initial clone or updating. Local copies should work the same as always.