### PR TITLE
[Fallout 4] Add "Copy Editor ID" & "Copy Form ID" to object window context menu.

### DIFF
--- a/CKPE.Common/Include/CKPE.Common.EditorUI.h
+++ b/CKPE.Common/Include/CKPE.Common.EditorUI.h
@@ -87,6 +87,8 @@ namespace CKPE
 			static void SuspendComboBoxUpdates(void* ComboHandle, bool Suspend) noexcept(true);
 			static void ComboBoxInsertItemDeferred(void* ComboBoxHandle, const char* DisplayText,
 				void* Value, bool AllowResize) noexcept(true);
+
+			static void CopyTextToClipboard(void* Hwnd, const char* Text) noexcept(true);
 		public:
 			struct CKPE_COMMON_API Hook
 			{

--- a/CKPE.Common/Src/CKPE.Common.EditorUI.cpp
+++ b/CKPE.Common/Src/CKPE.Common.EditorUI.cpp
@@ -354,6 +354,25 @@ namespace CKPE
 			}
 		}
 
+		void EditorUI::CopyTextToClipboard(void* Hwnd, const char* Text) noexcept(true)
+		{
+			if (!Text)
+				return;
+			if (OpenClipboard((HWND)Hwnd))
+			{
+				EmptyClipboard();
+				size_t len = strlen(Text) + 1;
+				HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, len);
+				if (hMem)
+				{
+					memcpy(GlobalLock(hMem), Text, len);
+					GlobalUnlock(hMem);
+					SetClipboardData(CF_TEXT, hMem);
+				}
+				CloseClipboard();
+			}
+		}
+
 		/////////////////////////////////////////
 
 		CriticalSection DialogLock;

--- a/CKPE.Fallout4/Src/Patches/CKPE.Fallout4.Patch.ObjectWindow.cpp
+++ b/CKPE.Fallout4/Src/Patches/CKPE.Fallout4.Patch.ObjectWindow.cpp
@@ -25,6 +25,11 @@
 #define UI_OBJECT_WINDOW_ADD_ITEM			2579
 #define UI_CMD_CHANGE_SPLITTER_OBJECTWINDOW	(WM_USER + 34400)
 
+#define UI_CMD_DUPLICATE_AND_RENAME			0xA0BF
+
+#define UI_CMD_COPY_EDITOR_ID 				0xA0BE
+#define UI_CMD_COPY_FORM_ID 				0xA0BD
+
 namespace CKPE
 {
 	namespace Fallout4
@@ -424,6 +429,27 @@ namespace CKPE
 
 						return S_OK;
 					}
+					else if (param == UI_CMD_COPY_EDITOR_ID || param == UI_CMD_COPY_FORM_ID)
+					{
+						auto ItemList = GetDlgItem(Hwnd, 1041);
+						CKPE_ASSERT(ItemList);
+
+						auto Form = (EditorAPI::Forms::TESForm*)Common::EditorUI::ListViewGetSelectedItem(ItemList);
+						CKPE_ASSERT(Form);
+
+						if (param == UI_CMD_COPY_EDITOR_ID)
+						{
+							Common::EditorUI::CopyTextToClipboard(Hwnd, Form->EditorID);
+						}
+						else
+						{
+							char szBuf[16]{};
+							sprintf_s(szBuf, "%08X", Form->FormID);
+							Common::EditorUI::CopyTextToClipboard(Hwnd, szBuf);
+						}
+
+						return S_OK;
+					}
 				}
 				else if (Message == UI_OBJECT_WINDOW_ADD_ITEM)
 				{
@@ -522,6 +548,25 @@ namespace CKPE
 						}
 
 						return S_OK;
+					}
+				}
+				else if (Message == WM_INITMENU)
+				{
+					HMENU hMenu = reinterpret_cast<HMENU>(wParam);
+					if (hMenu &&
+						GetMenuState(hMenu, UI_CMD_DUPLICATE_AND_RENAME, MF_BYCOMMAND) != (UINT)-1 &&
+						GetMenuState(hMenu, UI_CMD_COPY_EDITOR_ID, MF_BYCOMMAND) == (UINT)-1)
+					{
+						int count = GetMenuItemCount(hMenu);
+						for (int i = 0; i < count; i++)
+						{
+							if (GetMenuItemID(hMenu, i) == UI_CMD_DUPLICATE_AND_RENAME)
+							{
+								InsertMenuA(hMenu, i + 1, MF_BYPOSITION | MF_STRING,UI_CMD_COPY_EDITOR_ID, "Copy Editor ID");
+								InsertMenuA(hMenu, i + 2, MF_BYPOSITION | MF_STRING,UI_CMD_COPY_FORM_ID, "Copy Form ID");
+								break;
+							}
+						}
 					}
 				}
 


### PR DESCRIPTION
Add the options underneath "Duplicate and Rename", copied values goes directly to clipboard.

<img width="375" height="456" alt="image" src="https://github.com/user-attachments/assets/1d88bcdd-dd37-41ef-b16f-3b386b056ebe" />

