### PR TITLE
[SSE] Fix issues with cell view filter

### DIFF
--- a/CKPE.SkyrimSE/Src/Patches/CKPE.SkyrimSE.Patch.CellViewWindow.cpp
+++ b/CKPE.SkyrimSE/Src/Patches/CKPE.SkyrimSE.Patch.CellViewWindow.cpp
@@ -30,6 +30,8 @@
 
 #define UI_CELL_VIEW_FILTER_CELL_SIZE				1024
 
+#define UI_CELL_VIEW_FILTER_TIMER					0x24000
+
 namespace CKPE
 {
 	namespace SkyrimSE
@@ -230,7 +232,7 @@ namespace CKPE
 			{
 				if (!lock)
 					// Fake the dropdown list being activated
-					SendMessageA(Handle, WM_COMMAND, MAKEWPARAM(2083, 1), 0);
+					SendMessageA(Handle, WM_COMMAND, MAKEWPARAM(2083, CBN_SELCHANGE), 0);
 			}
 
 			void CellViewWindow::UpdateObjectList() noexcept(true)
@@ -322,16 +324,7 @@ namespace CKPE
 					}
 					else if ((param == UI_CELL_VIEW_FILTER_CELL) && (HIWORD(wParam) == EN_CHANGE))
 					{
-						auto hFilter = CellViewWindow::Singleton->m_FilterCellEdit.Handle;
-						auto iLen = std::min(GetWindowTextLengthA(hFilter), UI_CELL_VIEW_FILTER_CELL_SIZE - 1);
-
-						SetPropA(Hwnd, Common::EditorUI::UI_USER_DATA_FILTER_CELLS_LEN, reinterpret_cast<HANDLE>(iLen));
-
-						if (iLen)
-							GetWindowTextA(hFilter, str_CellViewWindow_FilterUser, iLen + 1);
-
-						CellViewWindow::Singleton->UpdateCellList();
-						return 1;
+						SetTimer(Hwnd, UI_CELL_VIEW_FILTER_TIMER, 500, NULL);
 					}
 					else if (param == UI_CELL_VIEW_GO_BUTTON)
 					{
@@ -339,6 +332,21 @@ namespace CKPE
 							(CellViewWindow::Singleton->m_YEdit.GetCaption().length() <= 1))
 							return 1;
 					}
+				}
+				else if ((Message == WM_TIMER) && (wParam == UI_CELL_VIEW_FILTER_TIMER))
+				{
+					KillTimer(Hwnd, UI_CELL_VIEW_FILTER_TIMER);
+					auto hFilter = CellViewWindow::Singleton->m_FilterCellEdit.Handle;
+					auto iLen = std::min(GetWindowTextLengthA(hFilter), UI_CELL_VIEW_FILTER_CELL_SIZE - 1);
+					
+					SetPropA(Hwnd, Common::EditorUI::UI_USER_DATA_FILTER_CELLS_LEN, reinterpret_cast<HANDLE>(iLen));
+					
+					if (iLen)
+						GetWindowTextA(hFilter, str_CellViewWindow_FilterUser, iLen + 1);
+					
+					CellViewWindow::Singleton->UpdateCellList();
+					CellViewWindow::Singleton->m_FilterCellEdit.SetFocus();
+					return 1;
 				}
 				else if (Message == UI_CELL_VIEW_ADD_CELL_ITEM)
 				{

--- a/CKPE.SkyrimSE/Src/Patches/CKPE.SkyrimSE.Patch.CellViewWindow.cpp
+++ b/CKPE.SkyrimSE/Src/Patches/CKPE.SkyrimSE.Patch.CellViewWindow.cpp
@@ -325,6 +325,7 @@ namespace CKPE
 					else if ((param == UI_CELL_VIEW_FILTER_CELL) && (HIWORD(wParam) == EN_CHANGE))
 					{
 						SetTimer(Hwnd, UI_CELL_VIEW_FILTER_TIMER, 500, NULL);
+						return 1;
 					}
 					else if (param == UI_CELL_VIEW_GO_BUTTON)
 					{


### PR DESCRIPTION
This fixes two issues with the cell filter:
- Every time the filter changed, the focus would shift to the cell list view, so I could only type one character in the filter at a time before having to click back into it to restore focus. Fixed by manually forcing focus back to the filter text box.
- The cell list view takes a long time to update, so typing in the filter text box created significant lag. Fixed by adding a timer to wait 500ms before applying the filter.

I fixed these issues for SSE. I don't know if they affect CK for any other games.

There is another issue I am not sure yet how to fix. Whenever there is any text in the cell filter, switching to that cell takes a very, very long time--several minutes for exteriors. I think the filter might be applying repeatedly while the cell loads, but I'm not sure.